### PR TITLE
Add node engine config to server package. include npmrc default regis…

### DIFF
--- a/server/.npmrc
+++ b/server/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/server/package.json
+++ b/server/package.json
@@ -16,5 +16,8 @@
   },
   "devDependencies": {
     "nodemon": "^2.0.6"
+  },
+  "engines": {
+    "node": "^14.0.0"
   }
 }


### PR DESCRIPTION
 include npmrc default registry to override jpmc normal setup. 
 We have a non-public registry normally (for folks using their own machines instead of your labs VMs)